### PR TITLE
feat: Expose custom Blake3 initialisers

### DIFF
--- a/Blake3.lean
+++ b/Blake3.lean
@@ -38,6 +38,9 @@ opaque init : Unit → Hasher
 @[extern "lean_blake3_init_keyed"]
 opaque init_keyed (key : @& ByteArray) : Hasher
 
+@[extern "lean_blake3_init_derive_key"]
+opaque init_derive_key (context : @& ByteArray) : Hasher
+
 /-- Put more data into the hasher. This can be called several times. -/
 @[extern "lean_blake3_hasher_update"]
 opaque update (hasher : Hasher) (input : @& ByteArray) : Hasher
@@ -61,6 +64,16 @@ def hash (input : ByteArray) : Blake3Hash :=
 /-- Hash a ByteArray using keyed initializer -/
 def hash_keyed (input key : ByteArray) : Blake3Hash :=
   let hasher := Hasher.init_keyed key
+  let hasher := hasher.update input
+  let output := hasher.finalize BLAKE3_OUT_LEN.toUSize
+  if h : output.size = BLAKE3_OUT_LEN then
+    ⟨output, h⟩
+  else
+    panic! "Incorrect output size"
+
+/-- Hash a ByteArray using initializer parameterized by some context -/
+def hash_derive_key (input context : ByteArray) : Blake3Hash :=
+  let hasher := Hasher.init_derive_key context
   let hasher := hasher.update input
   let output := hasher.finalize BLAKE3_OUT_LEN.toUSize
   if h : output.size = BLAKE3_OUT_LEN then

--- a/Blake3.lean
+++ b/Blake3.lean
@@ -34,6 +34,10 @@ namespace Hasher
 @[extern "lean_blake3_init"]
 opaque init : Unit → Hasher
 
+/-- Initialize a hasher using pseudo-random key -/
+@[extern "lean_blake3_init_keyed"]
+opaque init_keyed (key : @& ByteArray) : Hasher
+
 /-- Put more data into the hasher. This can be called several times. -/
 @[extern "lean_blake3_hasher_update"]
 opaque update (hasher : Hasher) (input : @& ByteArray) : Hasher
@@ -47,6 +51,16 @@ end Hasher
 /-- Hash a ByteArray -/
 def hash (input : ByteArray) : Blake3Hash :=
   let hasher := Hasher.init ()
+  let hasher := hasher.update input
+  let output := hasher.finalize BLAKE3_OUT_LEN.toUSize
+  if h : output.size = BLAKE3_OUT_LEN then
+    ⟨output, h⟩
+  else
+    panic! "Incorrect output size"
+
+/-- Hash a ByteArray using keyed initializer -/
+def hash_keyed (input key : ByteArray) : Blake3Hash :=
+  let hasher := Hasher.init_keyed key
   let hasher := hasher.update input
   let output := hasher.finalize BLAKE3_OUT_LEN.toUSize
   if h : output.size = BLAKE3_OUT_LEN then

--- a/Blake3Test.lean
+++ b/Blake3Test.lean
@@ -14,10 +14,15 @@ abbrev expected_output_keyed_hashing: ByteArray := ⟨#[
    145, 187, 220, 234, 206, 139, 205, 138, 220, 103, 35, 65, 199, 96, 210, 18, 145, 201, 131, 254, 79, 208, 229, 157, 2, 29, 12, 32, 17, 118, 181, 232
 ]⟩
 
+-- Context (with "bad" randomness)
+abbrev context : ByteArray := ⟨#[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]⟩
+abbrev expected_output_derive_key_hashing: ByteArray := ⟨#[34, 57, 22, 43, 164, 211, 65, 131, 90, 55, 55, 92, 68, 90, 63, 136, 3, 235, 52, 117, 143, 246, 158, 224, 178, 170, 234, 211, 148, 21, 97, 183]⟩
+
 def main : IO UInt32 := do
   println! s!"BLAKE3 version: {Blake3.version}"
   if
     /- Test 1 -/ (Blake3.hash input).val.data != expected_output_regular_hashing.data ||
-    /- Test 2 -/ (Blake3.hash_keyed input key).val.data != expected_output_keyed_hashing.data
+    /- Test 2 -/ (Blake3.hash_keyed input key).val.data != expected_output_keyed_hashing.data ||
+    /- Test 3 -/ (Blake3.hash_derive_key input context).val.data != expected_output_derive_key_hashing.data
           then IO.eprintln "BLAKE3 test failed";    return 1
           else IO.println  "BLAKE3 test succeeded"; return 0

--- a/Blake3Test.lean
+++ b/Blake3Test.lean
@@ -1,15 +1,23 @@
 import Blake3
 
 abbrev input : ByteArray := ⟨#[0]⟩
-abbrev output : ByteArray := ⟨#[
+abbrev expected_output_regular_hashing : ByteArray := ⟨#[
    45,  58, 222, 223, 241,  27,  97, 241,
    76, 136, 110,  53, 175, 160,  54, 115,
   109, 205, 135, 167,  77,  39, 181, 193,
    81,   2,  37, 208, 245, 146, 226,  19
 ]⟩
 
+-- Good pseudo-random key
+abbrev key : ByteArray := ⟨#[3, 123, 16, 175, 8, 196, 101, 134, 144, 184, 221, 34, 25, 106, 122, 200, 213, 14, 159, 189, 82, 166, 91, 107, 33, 78, 26, 226, 89, 65, 188, 92]⟩
+abbrev expected_output_keyed_hashing: ByteArray := ⟨#[
+   145, 187, 220, 234, 206, 139, 205, 138, 220, 103, 35, 65, 199, 96, 210, 18, 145, 201, 131, 254, 79, 208, 229, 157, 2, 29, 12, 32, 17, 118, 181, 232
+]⟩
+
 def main : IO UInt32 := do
   println! s!"BLAKE3 version: {Blake3.version}"
-  if (Blake3.hash input).val.data != output.data
-    then IO.eprintln "BLAKE3 test failed";    return 1
-    else IO.println  "BLAKE3 test succeeded"; return 0
+  if
+    /- Test 1 -/ (Blake3.hash input).val.data != expected_output_regular_hashing.data ||
+    /- Test 2 -/ (Blake3.hash_keyed input key).val.data != expected_output_keyed_hashing.data
+          then IO.eprintln "BLAKE3 test failed";    return 1
+          else IO.println  "BLAKE3 test succeeded"; return 0

--- a/Blake3Test.lean
+++ b/Blake3Test.lean
@@ -9,20 +9,31 @@ abbrev expected_output_regular_hashing : ByteArray := ⟨#[
 ]⟩
 
 -- Good pseudo-random key
-abbrev key : ByteArray := ⟨#[3, 123, 16, 175, 8, 196, 101, 134, 144, 184, 221, 34, 25, 106, 122, 200, 213, 14, 159, 189, 82, 166, 91, 107, 33, 78, 26, 226, 89, 65, 188, 92]⟩
+abbrev key : Blake3.Blake3Key := .ofBytes ⟨#[
+     3, 123,  16, 175,  8, 196, 101, 134,
+   144, 184, 221,  34, 25, 106, 122, 200,
+   213,  14, 159, 189, 82, 166,  91, 107,
+    33,  78,  26, 226, 89,  65, 188, 92
+]⟩
 abbrev expected_output_keyed_hashing: ByteArray := ⟨#[
-   145, 187, 220, 234, 206, 139, 205, 138, 220, 103, 35, 65, 199, 96, 210, 18, 145, 201, 131, 254, 79, 208, 229, 157, 2, 29, 12, 32, 17, 118, 181, 232
+   145, 187, 220, 234, 206, 139, 205, 138,
+   220, 103,  35,  65, 199,  96, 210,  18,
+   145, 201, 131, 254,  79, 208, 229, 157,
+     2,  29,  12,  32,  17, 118, 181, 232
 ]⟩
 
 -- Context (with "bad" randomness)
 abbrev context : ByteArray := ⟨#[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]⟩
-abbrev expected_output_derive_key_hashing: ByteArray := ⟨#[34, 57, 22, 43, 164, 211, 65, 131, 90, 55, 55, 92, 68, 90, 63, 136, 3, 235, 52, 117, 143, 246, 158, 224, 178, 170, 234, 211, 148, 21, 97, 183]⟩
+abbrev expected_output_derive_key_hashing: ByteArray := ⟨#[
+    34,  57,  22,  43, 164, 211,  65, 131,
+    90,  55,  55,  92,  68,  90,  63, 136,
+     3, 235,  52, 117, 143, 246, 158, 224,
+   178, 170, 234, 211, 148,  21,  97, 183]⟩
 
 def main : IO UInt32 := do
   println! s!"BLAKE3 version: {Blake3.version}"
-  if
-    /- Test 1 -/ (Blake3.hash input).val.data != expected_output_regular_hashing.data ||
-    /- Test 2 -/ (Blake3.hash_keyed input key).val.data != expected_output_keyed_hashing.data ||
-    /- Test 3 -/ (Blake3.hash_derive_key input context).val.data != expected_output_derive_key_hashing.data
-          then IO.eprintln "BLAKE3 test failed";    return 1
-          else IO.println  "BLAKE3 test succeeded"; return 0
+  if (Blake3.hash input).val.data != expected_output_regular_hashing.data ||
+     (Blake3.hashKeyed input key).val.data != expected_output_keyed_hashing.data ||
+     (Blake3.hashDeriveKey input context).val.data != expected_output_derive_key_hashing.data
+    then IO.eprintln "BLAKE3 test failed";    return 1
+    else IO.println  "BLAKE3 test succeeded"; return 0

--- a/ffi.c
+++ b/ffi.c
@@ -63,6 +63,15 @@ extern lean_obj_res lean_blake3_init_keyed(b_lean_obj_arg key) {
 }
 
 /**
+ * Initialize a hasher using some arbitrary context
+ */
+ extern lean_obj_res lean_blake3_init_derive_key(b_lean_obj_arg context) {
+     blake3_hasher *a = malloc(sizeof(blake3_hasher));
+     blake3_hasher_init_derive_key_raw(a, lean_sarray_cptr(context), lean_sarray_size(context));
+     return lean_alloc_external(get_blake3_hasher_class(), a);
+ }
+
+/**
  * Ensure the hasher is exclusive.
  */
 static inline lean_obj_res lean_ensure_exclusive_blake3_hasher(lean_obj_arg a) {

--- a/ffi.c
+++ b/ffi.c
@@ -56,7 +56,6 @@ extern lean_obj_res lean_blake3_init() {
  * Initialize a hasher using pseudo-random key
  */
 extern lean_obj_res lean_blake3_init_keyed(b_lean_obj_arg key) {
-    assert(lean_sarray_size(key) == 32)
     blake3_hasher *a = malloc(sizeof(blake3_hasher));
     blake3_hasher_init_keyed(a, lean_sarray_cptr(key));
     return lean_alloc_external(get_blake3_hasher_class(), a);

--- a/ffi.c
+++ b/ffi.c
@@ -53,6 +53,16 @@ extern lean_obj_res lean_blake3_init() {
 }
 
 /**
+ * Initialize a hasher using pseudo-random key
+ */
+extern lean_obj_res lean_blake3_init_keyed(b_lean_obj_arg key) {
+    assert(lean_sarray_size(key) == 32)
+    blake3_hasher *a = malloc(sizeof(blake3_hasher));
+    blake3_hasher_init_keyed(a, lean_sarray_cptr(key));
+    return lean_alloc_external(get_blake3_hasher_class(), a);
+}
+
+/**
  * Ensure the hasher is exclusive.
  */
 static inline lean_obj_res lean_ensure_exclusive_blake3_hasher(lean_obj_arg a) {


### PR DESCRIPTION
This PR exposes two more Blake3 initialisers (`keyed` and `derive`). They are required for SHO [object](https://github.com/storojs72/BLAKE3/blob/sho/reference_impl/reference_impl.rs#L448) (one that provides absorb & squeeze API) constructing that we are going to use in UTF-8 puzzle solution. 

The `keyed` hasher is more secure against traditional cryptanalysis than the `regular` one, having almost same performance. The caveat is that in some settings, the high-level caller is not able to provide good pseudo-random bytes for the key. To tackle this problem, there is a `derive_key` initialiser that allows constructing secure hasher using arbitrary (not pseudo-random) context. It has slower performance but still good security.