### PR TITLE
feat: Add Nix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,18 @@
 name: "CI"
+
 on:
   pull_request:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  lean-test:
+    name: Lean Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -13,3 +20,19 @@ jobs:
         with:
           build-args: "--wfail"
           test: true
+
+  nix-test:
+    name: Nix Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v15
+        with:
+          name: argumentcomputer
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build .#test
+      - run: nix run .#test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.lake
 /blake3
+result*

--- a/blake3.nix
+++ b/blake3.nix
@@ -1,0 +1,59 @@
+{pkgs, lean4-nix, blake3}:
+let
+  blake3Flags = pkgs.lib.concatStringsSep " " ([
+    "-DBLAKE3_NO_SSE2"
+    "-DBLAKE3_NO_SSE41"
+    "-DBLAKE3_NO_AVX2"
+    "-DBLAKE3_NO_AVX512"
+    "-DBLAKE3_USE_NEON=0"
+  ]);
+  #blake3Files = [
+  #  "blake3"
+  #  "blake3_dispatch"
+  #  "blake3_portable"
+  #];
+  blake3-c = pkgs.stdenv.mkDerivation {
+    name = "blake3-c";
+    src = ./.;
+    buildInputs = [ pkgs.gcc pkgs.lean.lean-all ];
+    buildPhase = ''
+      lean --version
+      gcc -O3 -Wall -c ${blake3}/c/blake3.c -o blake3.o ${blake3Flags}
+      gcc -O3 -Wall -c ${blake3}/c/blake3_dispatch.c -o blake3_dispatch.o ${blake3Flags}
+      gcc -O3 -Wall -c ${blake3}/c/blake3_portable.c -o blake3_portable.o ${blake3Flags}
+      gcc -O3 -Wall -c ffi.c -o ffi.o -I ${pkgs.lean4}/include -I ${blake3}/c
+      ar rcs libblake3.a blake3.o blake3_dispatch.o blake3_portable.o ffi.o
+    '';
+    installPhase = ''
+      mkdir -p $out/lib $out/include
+      cp libblake3.a $out/lib/
+      cp ${blake3}/c/blake3.h $out/include/
+    '';
+  };
+  blake3-lib = (pkgs.lean.buildLeanPackage {
+    name = "blake3-lib";
+    src = ./.;
+    roots = [ "Blake3" ];
+    staticLibDeps = [ blake3-c ];
+    linkFlags = [ "-L${blake3-c}/lib" "-lblake3" ];
+  });
+
+  blake3-test = (pkgs.lean.buildLeanPackage {
+    name = "blake3-test";
+    src = ./.;
+    roots = ["Blake3Test"];
+    deps = [ blake3-lib ];
+    staticLibDeps = [ blake3-c ];
+    linkFlags = [ "-L${blake3-c}/lib" "-lblake3" ];
+  });
+
+  lib = {
+    inherit
+      blake3-c
+      blake3-lib
+      blake3-test;
+  };
+in
+{
+  inherit lib;
+}

--- a/blake3.nix
+++ b/blake3.nix
@@ -1,59 +1,61 @@
-{pkgs, lean4-nix, blake3}:
-let
-  blake3Flags = pkgs.lib.concatStringsSep " " ([
+{
+  pkgs,
+  lean4-nix,
+  blake3,
+}: let
+  blake3Flags = pkgs.lib.concatStringsSep " " [
     "-DBLAKE3_NO_SSE2"
     "-DBLAKE3_NO_SSE41"
     "-DBLAKE3_NO_AVX2"
     "-DBLAKE3_NO_AVX512"
     "-DBLAKE3_USE_NEON=0"
-  ]);
-  #blake3Files = [
-  #  "blake3"
-  #  "blake3_dispatch"
-  #  "blake3_portable"
-  #];
+  ];
+  blake3Files = [
+    "blake3"
+    "blake3_dispatch"
+    "blake3_portable"
+  ];
+  buildSteps =
+    builtins.map (file: "gcc -O3 -Wall -c ${blake3}/c/${file}.c -o ${file}.o ${blake3Flags}") blake3Files
+    ++ [
+      "gcc -O3 -Wall -c ffi.c -o ffi.o -I ${pkgs.lean4}/include -I ${blake3}/c"
+      "ar rcs libblake3.a ${(builtins.concatStringsSep " " (builtins.map (str: "${str}.o") blake3Files))} ffi.o"
+    ];
   blake3-c = pkgs.stdenv.mkDerivation {
     name = "blake3-c";
     src = ./.;
-    buildInputs = [ pkgs.gcc pkgs.lean.lean-all ];
-    buildPhase = ''
-      lean --version
-      gcc -O3 -Wall -c ${blake3}/c/blake3.c -o blake3.o ${blake3Flags}
-      gcc -O3 -Wall -c ${blake3}/c/blake3_dispatch.c -o blake3_dispatch.o ${blake3Flags}
-      gcc -O3 -Wall -c ${blake3}/c/blake3_portable.c -o blake3_portable.o ${blake3Flags}
-      gcc -O3 -Wall -c ffi.c -o ffi.o -I ${pkgs.lean4}/include -I ${blake3}/c
-      ar rcs libblake3.a blake3.o blake3_dispatch.o blake3_portable.o ffi.o
-    '';
+    buildInputs = [pkgs.gcc pkgs.lean.lean-all];
+    buildPhase = builtins.concatStringsSep "\n" buildSteps;
     installPhase = ''
       mkdir -p $out/lib $out/include
       cp libblake3.a $out/lib/
       cp ${blake3}/c/blake3.h $out/include/
     '';
   };
-  blake3-lib = (pkgs.lean.buildLeanPackage {
+  blake3-lib = pkgs.lean.buildLeanPackage {
     name = "blake3-lib";
     src = ./.;
-    roots = [ "Blake3" ];
-    staticLibDeps = [ blake3-c ];
-    linkFlags = [ "-L${blake3-c}/lib" "-lblake3" ];
-  });
+    roots = ["Blake3"];
+    linkFlags = ["-L${blake3-c}/lib" "-lblake3"];
+    groupStaticLibs = true;
+  };
 
-  blake3-test = (pkgs.lean.buildLeanPackage {
+  blake3-test = pkgs.lean.buildLeanPackage {
     name = "blake3-test";
     src = ./.;
     roots = ["Blake3Test"];
-    deps = [ blake3-lib ];
-    staticLibDeps = [ blake3-c ];
-    linkFlags = [ "-L${blake3-c}/lib" "-lblake3" ];
-  });
+    deps = [blake3-lib];
+    linkFlags = ["-L${blake3-c}/lib" "-lblake3"];
+    groupStaticLibs = true;
+  };
 
   lib = {
     inherit
       blake3-c
       blake3-lib
-      blake3-test;
+      blake3-test
+      ;
   };
-in
-{
+in {
   inherit lib;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,127 @@
+{
+  "nodes": {
+    "blake3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1740955160,
+        "narHash": "sha256-Z07khB6ABvt6Q6YqOUAi9nFRXLZMfcEnjc3mH1OieUE=",
+        "owner": "BLAKE3-team",
+        "repo": "BLAKE3",
+        "rev": "9edb473fa81c422acc2cb611f55c4df52d1cdbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BLAKE3-team",
+        "repo": "BLAKE3",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1740872218,
+        "narHash": "sha256-ZaMw0pdoUKigLpv9HiNDH2Pjnosg7NBYMJlHTIsHEUo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3876f6b87db82f33775b1ef5ea343986105db764",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1740872218,
+        "narHash": "sha256-ZaMw0pdoUKigLpv9HiNDH2Pjnosg7NBYMJlHTIsHEUo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3876f6b87db82f33775b1ef5ea343986105db764",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "lean4-nix": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741177057,
+        "narHash": "sha256-xcd74c7oDQvEJHeQfJaJt7/HWBcCDrS5Ki0DtOEe1dA=",
+        "owner": "argumentcomputer",
+        "repo": "lean4-nix",
+        "rev": "29b86ca0f5c9db6186311b21fde6a634be3f2d74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "argumentcomputer",
+        "repo": "lean4-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1741173522,
+        "narHash": "sha256-k7VSqvv0r1r53nUI/IfPHCppkUAddeXn843YlAC5DR0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d69ab0d71b22fa1ce3dbeff666e6deb4917db049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1740872140,
+        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1740872140,
+        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "blake3": "blake3",
+        "flake-parts": "flake-parts",
+        "lean4-nix": "lean4-nix",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "Blake3 Nix Flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    lean4-nix = {
+      url = "github:argumentcomputer/lean4-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    blake3 = {
+      url = "github:BLAKE3-team/BLAKE3";
+      flake = false;
+    };
+  };
+
+  outputs = inputs @ {
+    nixpkgs,
+    flake-parts,
+    lean4-nix,
+    blake3,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      flake = {
+        lib = import ./blake3.nix;
+        inputs.blake3 = blake3;
+      };
+
+      perSystem = {
+        system,
+        pkgs,
+        ...
+      }: 
+      let
+        lib = (import ./blake3.nix { inherit pkgs lean4-nix blake3; }).lib;
+      in
+      {
+        _module.args.pkgs = import nixpkgs {
+          inherit system;
+          overlays = [(lean4-nix.readToolchainFile ./lean-toolchain)];
+        };
+
+        packages = {
+          test = lib.blake3-test.executable;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs.lean; [lean lean-all pkgs.gcc pkgs.clang ];
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
         "x86_64-linux"
       ];
 
+      # Flake output for use downstream
       flake = {
         lib = import ./blake3.nix;
         inputs.blake3 = blake3;
@@ -38,11 +39,9 @@
         system,
         pkgs,
         ...
-      }: 
-      let
-        lib = (import ./blake3.nix { inherit pkgs lean4-nix blake3; }).lib;
-      in
-      {
+      }: let
+        lib = (import ./blake3.nix {inherit pkgs lean4-nix blake3;}).lib;
+      in {
         _module.args.pkgs = import nixpkgs {
           inherit system;
           overlays = [(lean4-nix.readToolchainFile ./lean-toolchain)];
@@ -53,8 +52,10 @@
         };
 
         devShells.default = pkgs.mkShell {
-          packages = with pkgs.lean; [lean lean-all pkgs.gcc pkgs.clang ];
+          packages = with pkgs.lean; [lean lean-all pkgs.gcc pkgs.clang];
         };
+
+        formatter = pkgs.alejandra;
       };
     };
 }


### PR DESCRIPTION
- Nix flake for building and running Blake3.lean tests with C FFI
- Exports the Blake3 C static library for linking in downstream Lean package, as the `buildLeanPackage` function doesn't include static libraries in its built output (described further in https://github.com/argumentcomputer/lean4-nix/issues/8)
- CI job to run tests via Nix

> [!NOTE]
> This PR updates the CI job names, so the corresponding names of the required status checks will have to be updated before merge.