### PR TITLE
chore: Simplify Nix build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v16
         with:
           name: argumentcomputer
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix build .#test
-      - run: nix run .#test
+      - run: nix build
+      - run: nix run

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "blake3": {
       "flake": false,
       "locked": {
-        "lastModified": 1743660526,
-        "narHash": "sha256-NQCltEt1+CsKfho4nebzzH/R4lHdnDigNCRoJbxofrM=",
+        "lastModified": 1743710137,
+        "narHash": "sha256-bluvU/Jp+jILebV6jFnBz3bgSVPGYWGxPjffzG12qd0=",
         "owner": "BLAKE3-team",
         "repo": "BLAKE3",
-        "rev": "ad639b126ef9b5f3b131093363cc3bb6bba4c3bf",
+        "rev": "bafe693a8238803e6abcdba9dce291d209eb82c7",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1740872218,
-        "narHash": "sha256-ZaMw0pdoUKigLpv9HiNDH2Pjnosg7NBYMJlHTIsHEUo=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3876f6b87db82f33775b1ef5ea343986105db764",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741177057,
-        "narHash": "sha256-xcd74c7oDQvEJHeQfJaJt7/HWBcCDrS5Ki0DtOEe1dA=",
+        "lastModified": 1743712665,
+        "narHash": "sha256-NZo+2eqQO3YnwYBx6B+mcIpnet8YgD5zOT5FFUgruyM=",
         "owner": "argumentcomputer",
         "repo": "lean4-nix",
-        "rev": "29b86ca0f5c9db6186311b21fde6a634be3f2d74",
+        "rev": "4be3233202910e1ef352d4f99e3527ec67513849",
         "type": "github"
       },
       "original": {
@@ -106,14 +106,17 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1740872140,
-        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "blake3": {
       "flake": false,
       "locked": {
-        "lastModified": 1740955160,
-        "narHash": "sha256-Z07khB6ABvt6Q6YqOUAi9nFRXLZMfcEnjc3mH1OieUE=",
+        "lastModified": 1743660526,
+        "narHash": "sha256-NQCltEt1+CsKfho4nebzzH/R4lHdnDigNCRoJbxofrM=",
         "owner": "BLAKE3-team",
         "repo": "BLAKE3",
-        "rev": "9edb473fa81c422acc2cb611f55c4df52d1cdbbb",
+        "rev": "ad639b126ef9b5f3b131093363cc3bb6bba4c3bf",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1740872218,
-        "narHash": "sha256-ZaMw0pdoUKigLpv9HiNDH2Pjnosg7NBYMJlHTIsHEUo=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3876f6b87db82f33775b1ef5ea343986105db764",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741173522,
-        "narHash": "sha256-k7VSqvv0r1r53nUI/IfPHCppkUAddeXn843YlAC5DR0=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d69ab0d71b22fa1ce3dbeff666e6deb4917db049",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -91,14 +91,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740872140,
-        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixpkgs-lib_2": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,12 +29,6 @@
         "x86_64-linux"
       ];
 
-      # Flake output for use downstream
-      flake = {
-        lib = import ./blake3.nix;
-        inputs.blake3 = blake3;
-      };
-
       perSystem = {
         system,
         pkgs,
@@ -48,9 +42,17 @@
         };
 
         packages = {
-          test = lib.blake3-test.executable;
+          default = ((lean4-nix.lake {inherit pkgs;}).mkPackage {
+            src = ./.;
+            roots = ["Blake3Test"];
+            deps = [lib.blake3-lib];
+            staticLibDeps = [ "${lib.blake3-c}/lib" ];
+          })
+          .executable;
+          # Downstream lean4-nix packages must also link to the static lib using the `staticLibDeps` attribute.
+          # See https://github.com/argumentcomputer/lean4-nix/blob/dev/templates/dependency/flake.nix for an example
+          staticLib = lib.blake3-c;
         };
-
         devShells.default = pkgs.mkShell {
           packages = with pkgs.lean; [lean lean-all pkgs.gcc pkgs.clang];
         };


### PR DESCRIPTION
After https://github.com/argumentcomputer/lean4-nix/pull/10

- Switches to the `staticLibDeps` function in `mkPackage` to build external deps and static libs in one derivation
- Exports the `staticLib` package for use in downstream `mkPackage` derivations instead of the whole `blake3.nix` file via the `flake` output, which is simpler and doesn't require inheriting the `blake3` C library downstream